### PR TITLE
Fix: Correct negative margin right classes

### DIFF
--- a/styles/margin.scss
+++ b/styles/margin.scss
@@ -1907,131 +1907,131 @@
   --size--0_5: -0.125rem; // 2px
 	margin-right: var(--size--0_5);
 }
-.margin--1l {
+.margin--1r {
 	--size--1: -0.25rem; // 4px
   margin-right: var(--size--1);
 }
-.margin--1_5l {
+.margin--1_5r {
   --size--1_5: -0.375rem; // 6px
 	margin-right: var(--size--1_5);
 }
-.margin--2l {
+.margin--2r {
   --size--2: -0.5rem; // 8px
 	margin-right: var(--size--2);
 }
-.margin--2_5l {
+.margin--2_5r {
   --size--2_5: -0.625rem; // 10px
 	margin-right: var(--size--2_5);
 }
-.margin--3l {
+.margin--3r {
   --size--3: -0.75rem; // 12px
 	margin-right: var(--size--3);
 }
-.margin--3_5l {
+.margin--3_5r {
 	--size--3_5: -0.875rem; // 14px
   margin-right: var(--size--3_5);
 }
-.margin--4l {
+.margin--4r {
   --size--4: -1rem; // 16px
 	margin-right: var(--size--4);
 }
-.margin--5l {
+.margin--5r {
 	--size--5: -1.25rem; // 20px
   margin-right: var(--size--5);
 }
-.margin--6l {
+.margin--6r {
 	--size--6: -1.5rem; // 24px
   margin-right: var(--size--6);
 }
-.margin--7l {
+.margin--7r {
 	--size--7:  -1.75rem; // 28px
   margin-right: var(--size--7);
 }
-.margin--8l {
+.margin--8r {
 	--size--8: -2rem; // 32px
   margin-right: var(--size--8);
 }
-.margin--9l {
+.margin--9r {
 	--size--9: -2.25rem; // 36px
   margin-right: var(--size--9);
 }
-.margin--10l {
+.margin--10r {
 	--size--10: -2.5rem; // 40px
   margin-right: var(--size--10);
 }
-.margin--11l {
+.margin--11r {
 	--size--11: -2.75rem; // 44px
   margin-right: var(--size--11);
 }
-.margin--12l {
+.margin--12r {
 	--size--12: -3rem; // 48px
   margin-right: var(--size--12);
 }
-.margin--14l {
+.margin--14r {
 	--size--14: -3.5rem; // 56px
   margin-right: var(--size--14);
 }
-.margin--16l {
+.margin--16r {
 	--size--16: -4rem; // 64px
   margin-right: var(--size--16);
 }
-.margin--20l {
+.margin--20r {
 	--size--20: -5rem; // 80px
   margin-right: var(--size--20);
 }
-.margin--24l {
+.margin--24r {
 	--size--24: -6rem; // 96px
   margin-right: var(--size--24);
 }
-.margin--28l {
+.margin--28r {
 	--size--28: -7rem; // 112px
   margin-right: var(--size--28);
 }
-.margin--32l {
+.margin--32r {
 	--size--32: -8rem; // 128px
   margin-right: var(--size--32);
 }
-.margin--36l {
+.margin--36r {
 	--size--36: -9rem; // 144px
   margin-right: var(--size--36);
 }
-.margin--40l {
+.margin--40r {
 	--size--40: -10rem; // 160px
   margin-right: var(--size--40);
 }
-.margin--44l {
+.margin--44r {
 	--size--44: -11rem; // 176px
   margin-right: var(--size--44);
 }
-.margin--48l {
+.margin--48r {
 	--size--48: -12rem; // 192px
   margin-right: var(--size--48);
 }
-.margin--52l {
+.margin--52r {
 	--size--52: -13rem; // 208px
   margin-right: var(--size--52);
 }
-.margin--56l {
+.margin--56r {
 	--size--56: -14rem; // 224px
   margin-right: var(--size--56);
 }
-.margin--60l {
+.margin--60r {
 	--size--60: -15rem; // 240px
   margin-right: var(--size--60);
 }
-.margin--64l {
+.margin--64r {
 	--size--64: -16rem; // 256px
   margin-right: var(--size--64);
 }
-.margin--72l {
+.margin--72r {
 	--size--72: -18rem; // 288px
   margin-right: var(--size--72);
 }
-.margin--80l {
+.margin--80r {
 	--size--80: -20rem; // 320px
   margin-right: var(--size--80);
 }
-.margin--96l {
+.margin--96r {
 	--size--96: -24rem; // 384px
   margin-right: var(--size--96);
 }


### PR DESCRIPTION
### Description

The negative margin-right classes had the incorrect name. They were using syntax for left instead of right. This PR addresses this mismatch.

### Changes

- [x] Closes Github Issue #10 
